### PR TITLE
Fix for iOS 11

### DIFF
--- a/SceneKitOffscreen/ViewController.swift
+++ b/SceneKitOffscreen/ViewController.swift
@@ -125,6 +125,8 @@ class ViewController: UIViewController, SCNSceneRendererDelegate {
 
         let textureDescriptor = MTLTextureDescriptor.texture2DDescriptor(pixelFormat: MTLPixelFormat.rgba8Unorm, width: Int(textureSizeX), height: Int(textureSizeY), mipmapped: false)
         
+        textureDescriptor.usage = MTLTextureUsage(rawValue: MTLTextureUsage.renderTarget.rawValue | MTLTextureUsage.shaderRead.rawValue)
+        
         let textureA = device.makeTexture(descriptor: textureDescriptor)
         
         let region = MTLRegionMake2D(0, 0, Int(textureSizeX), Int(textureSizeY))


### PR DESCRIPTION
Without this pull request, on iOS 11 the runtime error is given:

```validateRenderPassDescriptor:487: failed assertion `Texture at colorAttachment[0] has usage (0x01) which doesn't specify MTLTextureUsageRenderTarget (0x04)'```